### PR TITLE
Fixed sequelize callback signature.

### DIFF
--- a/lib/connect-sequelize.js
+++ b/lib/connect-sequelize.js
@@ -60,7 +60,7 @@ module.exports = function SequelizeSessionInit(express) {
 	SequelizeStore.prototype.set = function setSession(sid, data, fn) {
 		debug('INSERT "%s"', sid);
 		var stringData = JSON.stringify(data);
-		this.sessionModel.findOrCreate({'sid': sid}, {'data': stringData}).success(function sessionCreated(session) {
+		this.sessionModel.findOrCreate({'sid': sid}, {'data': stringData}).success(function sessionCreated(session, created) {
 			if(session['data'] !== stringData) {
 				session['data'] = JSON.stringify(data);
 				session.save().success(function updated(session) {


### PR DESCRIPTION
It might be a bug in sequelize, but currently when with findOrCreate success
callback is passed a function with one argument it clamps both arguments
(model, isCreated) into an array and pass that instead.

e.g. this:
findOrCreate(...).success(function callback(model) {console.log(model)})
outputs:
[Object object, true]
