### PR TITLE
Fixed docs for setting up with express

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ var express = require('express'),
     session = require('express-session');
 
 // initalize sequelize with session store
-var SequelizeStore = require('connect-sequelize')(session.Store),
+var SequelizeStore = require('connect-sequelize')(session),
     modelName = 'Session',
     options = {
         // our options if any. see above for example.


### PR DESCRIPTION
In connect-sequelize.js:20 the passed argument is used as:

module.exports = function SequelizeSessionInit(express) {
    var Store = express.Store || express.session.Store;
...
}
